### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ on:
       - 'src/bot/requirements.txt'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/g-kari/discord-friend/security/code-scanning/8](https://github.com/g-kari/discord-friend/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only performs testing tasks, the minimal required permission is `contents: read`. This ensures that the workflow has the least privilege necessary to complete its tasks.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. Alternatively, it can be added specifically to the `test` job if other jobs in the workflow require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
