### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/scripts/check_git_secrets.py
+++ b/scripts/check_git_secrets.py
@@ -180,7 +180,8 @@ class GitSecretScanner:
             print("\nSecrets found:")
             
             for secret in commit['secrets']:
-                print(f"  - Type: {secret['type']}")
+                masked_type = secret['type'][:2] + '****' if len(secret['type']) > 4 else '****'
+                print(f"  - Type: {masked_type}")
                 # Mask the actual value in the output
                 masked_value = secret['value'][:4] + '****' + secret['value'][-4:] if len(secret['value']) > 8 else '****'
                 print(f"    Value: {masked_value}")

--- a/scripts/check_git_secrets.py
+++ b/scripts/check_git_secrets.py
@@ -180,7 +180,7 @@ class GitSecretScanner:
             print("\nSecrets found:")
             
             for secret in commit['secrets']:
-                masked_type = secret['type'][:2] + '****' if len(secret['type']) > 4 else '****'
+                masked_type = "Sensitive Type"
                 print(f"  - Type: {masked_type}")
                 # Mask the actual value in the output
                 masked_value = secret['value'][:4] + '****' + secret['value'][-4:] if len(secret['value']) > 8 else '****'


### PR DESCRIPTION
Potential fix for [https://github.com/g-kari/discord-friend/security/code-scanning/6](https://github.com/g-kari/discord-friend/security/code-scanning/6)

To fix the issue, we will avoid logging the exact type of the secret in clear text. Instead, we will replace it with a generic label such as "Sensitive Data" or mask the type to obscure its meaning. This ensures that no potentially sensitive metadata is exposed in the logs.

Steps to implement the fix:
1. Modify the `print_report` method in the `GitSecretScanner` class.
2. Replace the logging of `secret['type']` with a generic label or a masked version of the type.
3. Ensure that the fix does not affect the functionality of the script.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
