### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/scripts/check_git_secrets.py
+++ b/scripts/check_git_secrets.py
@@ -175,8 +175,7 @@ class GitSecretScanner:
         
         for i, commit in enumerate(self.findings):
             print(f"Commit: {commit['hash']}")
-            sanitized_author = commit['author'].split('@')[0] if '@' in commit['author'] else commit['author']
-            print(f"Author: {sanitized_author} (sanitized)")
+            print("Author: [REDACTED]")
             print(f"Date:   {commit['date']}")
             print("\nSecrets found:")
             

--- a/scripts/check_git_secrets.py
+++ b/scripts/check_git_secrets.py
@@ -175,7 +175,8 @@ class GitSecretScanner:
         
         for i, commit in enumerate(self.findings):
             print(f"Commit: {commit['hash']}")
-            print(f"Author: {commit['author']}")
+            sanitized_author = commit['author'].split('@')[0] if '@' in commit['author'] else commit['author']
+            print(f"Author: {sanitized_author} (sanitized)")
             print(f"Date:   {commit['date']}")
             print("\nSecrets found:")
             


### PR DESCRIPTION
Potential fix for [https://github.com/g-kari/discord-friend/security/code-scanning/4](https://github.com/g-kari/discord-friend/security/code-scanning/4)

To address the issue, we will sanitize or mask the `author` field before logging it. Instead of logging the full author information, we can log only a non-sensitive portion (e.g., the username without the email domain) or replace it with a placeholder. This approach ensures that sensitive data is not exposed while still providing useful information for debugging or reporting.

The changes will involve:
1. Modifying the `print_report` method to sanitize the `author` field before logging it.
2. Ensuring that the rest of the functionality remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
